### PR TITLE
Add onboarding guide and interactive feedback

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Quiz d'initiation informatique</title>
+    <link rel="stylesheet" href="styles/main.css">
+</head>
+<body>
+    <header class="top-bar">
+        <div class="brand">
+            <span aria-hidden="true" class="brand-icon">💡</span>
+            <h1>Initiation Informatique</h1>
+        </div>
+        <nav class="top-nav" aria-label="Navigation principale">
+            <a href="#quiz">Quiz</a>
+            <a href="#aides">Astuces</a>
+            <a href="#contact">Contact</a>
+            <button id="help-trigger" type="button" class="help-button" aria-haspopup="dialog">Aide</button>
+        </nav>
+    </header>
+
+    <main>
+        <section id="quiz" class="card">
+            <h2>Quiz : Premiers pas sur Internet</h2>
+            <p>Répondez à la question ci-dessous pour vérifier vos connaissances.</p>
+            <form id="quiz-form">
+                <fieldset>
+                    <legend>Quelle est la manière la plus sûre de créer un mot de passe&nbsp;?</legend>
+                    <label class="option">
+                        <input type="radio" name="password" value="simple" required>
+                        Utiliser le même mot de passe simple partout.
+                    </label>
+                    <label class="option">
+                        <input type="radio" name="password" value="complexe">
+                        Choisir un mot de passe long avec lettres, chiffres et symboles.
+                    </label>
+                    <label class="option">
+                        <input type="radio" name="password" value="notes">
+                        Écrire son mot de passe sur un post-it et le coller sur l'écran.
+                    </label>
+                </fieldset>
+                <button type="submit" class="primary">Valider</button>
+            </form>
+            <div id="quiz-status" class="alert alert-info" role="status" aria-live="polite" hidden>
+                <div class="alert-content">
+                    <span class="alert-icon" aria-hidden="true">🛡️</span>
+                    <div class="alert-body">
+                        <p class="alert-title">Votre réponse a été analysée</p>
+                        <p class="alert-message"></p>
+                        <div class="alert-actions">
+                            <button type="button" class="secondary" data-action="retry-quiz">Recommencer</button>
+                            <button type="button" class="primary" data-action="continue-quiz">Continuer</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="aides" class="card">
+            <h2>Astuces essentielles</h2>
+            <ul class="tips">
+                <li>Utilisez un mot de passe différent pour chaque site.</li>
+                <li>Mettez vos logiciels à jour régulièrement.</li>
+                <li>En cas de doute sur un message, demandez conseil avant de cliquer.</li>
+            </ul>
+        </section>
+
+        <section id="contact" class="card">
+            <h2>Besoin d'aide&nbsp;?</h2>
+            <p>Envoyez-nous un message, nous vous répondrons rapidement.</p>
+            <form id="contact-form">
+                <label for="name">Votre nom</label>
+                <input type="text" id="name" name="name" required>
+
+                <label for="email">Votre e-mail</label>
+                <input type="email" id="email" name="email" required>
+
+                <label for="message">Message</label>
+                <textarea id="message" name="message" rows="4" required></textarea>
+
+                <button type="submit" class="primary">Envoyer</button>
+            </form>
+            <div id="form-status" class="alert alert-success" role="status" aria-live="polite" hidden>
+                <div class="alert-content">
+                    <span class="alert-icon" aria-hidden="true">✅</span>
+                    <div class="alert-body">
+                        <p class="alert-title">Message bien reçu&nbsp;!</p>
+                        <p class="alert-message"></p>
+                        <div class="alert-actions">
+                            <button type="button" class="secondary" data-action="retry-form">Recommencer</button>
+                            <button type="button" class="primary" data-action="continue-form">Continuer</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <div id="onboarding-modal" class="onboarding" role="dialog" aria-modal="true" aria-labelledby="onboarding-title" hidden>
+        <div class="onboarding-backdrop" data-action="close"></div>
+        <div class="onboarding-dialog" role="document" tabindex="-1">
+            <header class="onboarding-header">
+                <h2 id="onboarding-title">Bienvenue sur le guide</h2>
+                <button type="button" class="close" data-action="close" aria-label="Fermer">×</button>
+            </header>
+            <div class="onboarding-steps">
+                <article class="onboarding-step" data-step="1" aria-hidden="false">
+                    <figure>
+                        <svg viewBox="0 0 120 80" role="img" aria-labelledby="step1-title">
+                            <title id="step1-title">Explorer la navigation</title>
+                            <rect x="5" y="5" width="110" height="50" rx="6" fill="#dbeafe"></rect>
+                            <rect x="15" y="20" width="90" height="10" rx="5" fill="#60a5fa"></rect>
+                            <circle cx="20" cy="65" r="8" fill="#f59e0b"></circle>
+                        </svg>
+                    </figure>
+                    <h3>Repérez-vous facilement</h3>
+                    <p>La barre supérieure vous guide vers les sections Quiz, Astuces et Contact. Utilisez le bouton «&nbsp;Aide&nbsp;» à tout moment.</p>
+                </article>
+                <article class="onboarding-step" data-step="2" aria-hidden="true">
+                    <figure>
+                        <svg viewBox="0 0 120 80" role="img" aria-labelledby="step2-title">
+                            <title id="step2-title">Répondre au quiz</title>
+                            <rect x="10" y="10" width="100" height="60" rx="8" fill="#dcfce7"></rect>
+                            <polyline points="25,45 50,65 95,20" fill="none" stroke="#22c55e" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"></polyline>
+                        </svg>
+                    </figure>
+                    <h3>Validez vos connaissances</h3>
+                    <p>Répondez au quiz et obtenez un retour immédiat. Les boutons «&nbsp;Recommencer&nbsp;» et «&nbsp;Continuer&nbsp;» vous accompagnent.</p>
+                </article>
+                <article class="onboarding-step" data-step="3" aria-hidden="true">
+                    <figure>
+                        <svg viewBox="0 0 120 80" role="img" aria-labelledby="step3-title">
+                            <title id="step3-title">Envoyer un message</title>
+                            <rect x="8" y="8" width="104" height="64" rx="10" fill="#ede9fe"></rect>
+                            <path d="M20 25 L60 45 L100 25" fill="none" stroke="#8b5cf6" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"></path>
+                            <rect x="35" y="50" width="50" height="10" rx="5" fill="#a855f7"></rect>
+                        </svg>
+                    </figure>
+                    <h3>Contactez-nous sereinement</h3>
+                    <p>Envoyez un message depuis la section Contact. Un résumé clair confirme l'envoi et vous guide vers la suite.</p>
+                </article>
+                <article class="onboarding-step" data-step="4" aria-hidden="true">
+                    <figure>
+                        <svg viewBox="0 0 120 80" role="img" aria-labelledby="step4-title">
+                            <title id="step4-title">Profitez des aides</title>
+                            <rect x="10" y="10" width="100" height="60" rx="12" fill="#fef3c7"></rect>
+                            <circle cx="45" cy="40" r="14" fill="#fbbf24"></circle>
+                            <path d="M70 30 L95 30" stroke="#f97316" stroke-width="6" stroke-linecap="round"></path>
+                            <path d="M70 50 L95 50" stroke="#f97316" stroke-width="6" stroke-linecap="round"></path>
+                        </svg>
+                    </figure>
+                    <h3>Retrouvez les bonnes pratiques</h3>
+                    <p>Consultez les astuces essentielles pour sécuriser vos usages numériques. Nous sommes là pour vous accompagner.</p>
+                </article>
+            </div>
+            <footer class="onboarding-footer">
+                <button type="button" class="secondary" data-action="prev">Précédent</button>
+                <button type="button" class="primary" data-action="next">Suivant</button>
+                <button type="button" class="link" data-action="close">Terminer</button>
+            </footer>
+        </div>
+    </div>
+
+    <script src="scripts/onboarding.js" defer></script>
+    <script src="scripts/app.js" defer></script>
+</body>
+</html>

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -1,0 +1,118 @@
+(function () {
+    function ready(fn) {
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', fn, { once: true });
+        } else {
+            fn();
+        }
+    }
+
+    function setAlert(alertElement, { message, icon, tone, title }) {
+        if (!alertElement) return;
+
+        const iconElement = alertElement.querySelector('.alert-icon');
+        const messageElement = alertElement.querySelector('.alert-message');
+        const titleElement = alertElement.querySelector('.alert-title');
+
+        alertElement.classList.remove('alert-success', 'alert-info');
+        if (tone === 'success') {
+            alertElement.classList.add('alert-success');
+        } else {
+            alertElement.classList.add('alert-info');
+        }
+
+        if (titleElement) {
+            const defaultTitle = tone === 'success' ? 'Bravo !' : 'Information importante';
+            titleElement.textContent = title || defaultTitle;
+        }
+
+        if (iconElement) {
+            iconElement.textContent = icon;
+        }
+
+        if (messageElement) {
+            messageElement.textContent = message;
+        }
+
+        alertElement.removeAttribute('hidden');
+    }
+
+    function hideAlert(alertElement) {
+        if (!alertElement) return;
+        alertElement.setAttribute('hidden', '');
+    }
+
+    ready(() => {
+        const quizForm = document.getElementById('quiz-form');
+        const quizStatus = document.getElementById('quiz-status');
+        const quizRetry = quizStatus?.querySelector('[data-action="retry-quiz"]');
+        const quizContinue = quizStatus?.querySelector('[data-action="continue-quiz"]');
+
+        const contactForm = document.getElementById('contact-form');
+        const formStatus = document.getElementById('form-status');
+        const formRetry = formStatus?.querySelector('[data-action="retry-form"]');
+        const formContinue = formStatus?.querySelector('[data-action="continue-form"]');
+
+        if (quizForm && quizStatus) {
+            quizForm.addEventListener('submit', (event) => {
+                event.preventDefault();
+                const formData = new FormData(quizForm);
+                const answer = formData.get('password');
+                const isCorrect = answer === 'complexe';
+
+                setAlert(quizStatus, {
+                    message: isCorrect
+                        ? 'Excellente réponse ! Un mot de passe complexe protège mieux vos comptes.'
+                        : 'Pensez à choisir un mot de passe long et unique pour chaque site afin de rester protégé.',
+                    icon: isCorrect ? '🎉' : '💡',
+                    tone: isCorrect ? 'success' : 'info',
+                    title: isCorrect ? 'Bonne réponse !' : 'Un petit rappel',
+                });
+
+                const alertFocusTarget = quizStatus.querySelector('.alert-actions .primary');
+                alertFocusTarget?.focus?.();
+            });
+
+            quizRetry?.addEventListener('click', () => {
+                quizForm.reset();
+                hideAlert(quizStatus);
+                const firstOption = quizForm.querySelector('input[type="radio"]');
+                firstOption?.focus?.();
+            });
+
+            quizContinue?.addEventListener('click', () => {
+                hideAlert(quizStatus);
+                document.getElementById('aides')?.scrollIntoView({ behavior: 'smooth' });
+            });
+        }
+
+        if (contactForm && formStatus) {
+            contactForm.addEventListener('submit', (event) => {
+                event.preventDefault();
+                const formData = new FormData(contactForm);
+                const name = formData.get('name')?.toString().trim() || 'cher utilisateur';
+
+                setAlert(formStatus, {
+                    message: `Merci ${name}, votre message a bien été envoyé. Nous reviendrons vers vous rapidement.`,
+                    icon: '🤝',
+                    tone: 'success',
+                    title: 'Message bien reçu !',
+                });
+
+                const alertFocusTarget = formStatus.querySelector('.alert-actions .primary');
+                alertFocusTarget?.focus?.();
+            });
+
+            formRetry?.addEventListener('click', () => {
+                contactForm.reset();
+                hideAlert(formStatus);
+                contactForm.querySelector('input, textarea')?.focus?.();
+            });
+
+            formContinue?.addEventListener('click', () => {
+                hideAlert(formStatus);
+                window.scrollTo({ top: 0, behavior: 'smooth' });
+            });
+        }
+    });
+})();

--- a/scripts/onboarding.js
+++ b/scripts/onboarding.js
@@ -1,0 +1,115 @@
+(function () {
+    const storageKey = 'onboardingSeen';
+
+    function ready(fn) {
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', fn, { once: true });
+        } else {
+            fn();
+        }
+    }
+
+    ready(() => {
+        const modal = document.getElementById('onboarding-modal');
+        if (!modal) {
+            return;
+        }
+
+        const steps = Array.from(modal.querySelectorAll('.onboarding-step'));
+        const helpButton = document.getElementById('help-trigger');
+        const nextButton = modal.querySelector('[data-action="next"]');
+        const prevButton = modal.querySelector('[data-action="prev"]');
+        const closeButtons = modal.querySelectorAll('[data-action="close"]');
+        const dialog = modal.querySelector('.onboarding-dialog');
+        let currentIndex = 0;
+        let openedFromHelp = false;
+
+        function updateSteps() {
+            steps.forEach((step, index) => {
+                const active = index === currentIndex;
+                step.setAttribute('aria-hidden', String(!active));
+            });
+            if (prevButton) {
+                prevButton.disabled = currentIndex === 0;
+            }
+            if (nextButton) {
+                nextButton.textContent = currentIndex === steps.length - 1 ? 'Terminer' : 'Suivant';
+            }
+        }
+
+        function openModal(fromHelp = false) {
+            openedFromHelp = fromHelp;
+            modal.hidden = false;
+            document.body.setAttribute('data-onboarding-open', 'true');
+            currentIndex = 0;
+            updateSteps();
+            requestAnimationFrame(() => {
+                dialog?.focus?.();
+            });
+        }
+
+        function closeModal() {
+            modal.hidden = true;
+            document.body.removeAttribute('data-onboarding-open');
+            if (!openedFromHelp) {
+                try {
+                    localStorage.setItem(storageKey, 'true');
+                } catch (error) {
+                    console.warn('Impossible d’enregistrer le tutoriel', error);
+                }
+            }
+            openedFromHelp = false;
+        }
+
+        function handleNext() {
+            if (currentIndex < steps.length - 1) {
+                currentIndex += 1;
+                updateSteps();
+            } else {
+                closeModal();
+            }
+        }
+
+        function handlePrev() {
+            if (currentIndex > 0) {
+                currentIndex -= 1;
+                updateSteps();
+            }
+        }
+
+        nextButton?.addEventListener('click', handleNext);
+        prevButton?.addEventListener('click', handlePrev);
+        closeButtons.forEach((button) => {
+            button.addEventListener('click', closeModal);
+        });
+
+        modal.addEventListener('click', (event) => {
+            const target = event.target;
+            if (target instanceof HTMLElement && target.dataset.action === 'close') {
+                closeModal();
+            }
+        });
+
+        modal.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape') {
+                closeModal();
+            }
+        });
+
+        if (helpButton) {
+            helpButton.addEventListener('click', () => {
+                openModal(true);
+            });
+        }
+
+        try {
+            const hasSeen = localStorage.getItem(storageKey);
+            if (!hasSeen) {
+                openModal(false);
+            }
+        } catch (error) {
+            console.warn('Accès à localStorage impossible', error);
+            openModal(false);
+        }
+    });
+})();

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,0 +1,340 @@
+:root {
+    color-scheme: light;
+    --color-background: #f8fafc;
+    --color-surface: #ffffff;
+    --color-text: #1e293b;
+    --color-muted: #475569;
+    --color-primary: #2563eb;
+    --color-primary-contrast: #ffffff;
+    --color-accent: #fbbf24;
+    --shadow-soft: 0 12px 24px rgba(15, 23, 42, 0.08);
+    --radius-large: 18px;
+    --radius-medium: 12px;
+    --transition: 200ms ease;
+
+    --alert-success-bg: #ecfdf5;
+    --alert-success-border: #34d399;
+    --alert-info-bg: #eef2ff;
+    --alert-info-border: #6366f1;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+    background: var(--color-background);
+    color: var(--color-text);
+    line-height: 1.6;
+}
+
+.top-bar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1rem 2rem;
+    background: linear-gradient(90deg, #1d4ed8, #2563eb);
+    color: var(--color-primary-contrast);
+    position: sticky;
+    top: 0;
+    z-index: 20;
+}
+
+.brand {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.brand-icon {
+    font-size: 1.5rem;
+}
+
+.top-nav {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+}
+
+.top-nav a {
+    color: var(--color-primary-contrast);
+    text-decoration: none;
+    font-weight: 600;
+}
+
+.help-button {
+    background: var(--color-primary-contrast);
+    color: var(--color-primary);
+    border: none;
+    border-radius: 999px;
+    padding: 0.5rem 1.25rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform var(--transition), box-shadow var(--transition);
+}
+
+.help-button:focus,
+.help-button:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 16px rgba(37, 99, 235, 0.3);
+}
+
+main {
+    max-width: 960px;
+    margin: 2rem auto;
+    padding: 0 1.5rem 4rem;
+    display: grid;
+    gap: 2rem;
+}
+
+.card {
+    background: var(--color-surface);
+    border-radius: var(--radius-large);
+    padding: 2rem;
+    box-shadow: var(--shadow-soft);
+}
+
+.card h2 {
+    margin-top: 0;
+    font-size: 1.75rem;
+}
+
+.option {
+    display: flex;
+    gap: 0.75rem;
+    align-items: flex-start;
+    padding: 0.75rem;
+    border-radius: var(--radius-medium);
+    border: 2px solid transparent;
+    transition: border-color var(--transition), background var(--transition);
+}
+
+.option:hover,
+.option:focus-within {
+    background: rgba(37, 99, 235, 0.08);
+    border-color: var(--color-primary);
+}
+
+.primary,
+.secondary,
+.link {
+    font-size: 1rem;
+    border-radius: 999px;
+    padding: 0.65rem 1.5rem;
+    cursor: pointer;
+    font-weight: 600;
+    border: none;
+    transition: background var(--transition), color var(--transition), transform var(--transition);
+}
+
+.primary {
+    background: var(--color-primary);
+    color: var(--color-primary-contrast);
+}
+
+.secondary {
+    background: #e2e8f0;
+    color: var(--color-text);
+}
+
+.link {
+    background: transparent;
+    color: var(--color-primary);
+    padding: 0.65rem 1rem;
+}
+
+.primary:hover,
+.primary:focus {
+    transform: translateY(-1px);
+    background: #1d4ed8;
+}
+
+.secondary:hover,
+.secondary:focus {
+    background: #cbd5f5;
+}
+
+.link:hover,
+.link:focus {
+    text-decoration: underline;
+}
+
+input,
+textarea {
+    width: 100%;
+    padding: 0.85rem 1rem;
+    border-radius: var(--radius-medium);
+    border: 1px solid #cbd5f5;
+    font-size: 1rem;
+    margin-bottom: 1rem;
+}
+
+textarea {
+    resize: vertical;
+}
+
+.alert {
+    margin-top: 1.5rem;
+    border-radius: var(--radius-large);
+    padding: 1.5rem;
+    max-width: 600px;
+    border: 2px solid transparent;
+    display: block;
+}
+
+.alert[hidden] {
+    display: none !important;
+}
+
+.alert.alert-success {
+    background: var(--alert-success-bg);
+    border-color: var(--alert-success-border);
+}
+
+.alert.alert-info {
+    background: var(--alert-info-bg);
+    border-color: var(--alert-info-border);
+}
+
+.alert-content {
+    display: flex;
+    gap: 1rem;
+    align-items: flex-start;
+}
+
+.alert-icon {
+    font-size: 2rem;
+}
+
+.alert-title {
+    font-size: 1.25rem;
+    margin: 0 0 0.5rem;
+}
+
+.alert-message {
+    margin: 0 0 1rem;
+    color: var(--color-muted);
+}
+
+.alert-actions {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+}
+
+.onboarding[hidden] {
+    display: none;
+}
+
+.onboarding {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 50;
+}
+
+.onboarding-backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.55);
+}
+
+.onboarding-dialog {
+    position: relative;
+    background: var(--color-surface);
+    border-radius: var(--radius-large);
+    padding: 2rem;
+    width: min(90%, 640px);
+    box-shadow: 0 24px 48px rgba(15, 23, 42, 0.3);
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.onboarding-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.close {
+    border: none;
+    background: transparent;
+    font-size: 1.75rem;
+    cursor: pointer;
+    line-height: 1;
+}
+
+.onboarding-steps {
+    display: grid;
+}
+
+.onboarding-step {
+    display: none;
+    text-align: center;
+    color: var(--color-text);
+}
+
+.onboarding-step[aria-hidden="false"] {
+    display: block;
+}
+
+.onboarding-step figure {
+    margin: 0 auto 1rem;
+    width: min(260px, 80%);
+}
+
+.onboarding-step svg {
+    width: 100%;
+    height: auto;
+}
+
+.onboarding-step h3 {
+    margin: 0 0 0.75rem;
+    font-size: 1.5rem;
+}
+
+.onboarding-step p {
+    margin: 0;
+    color: var(--color-muted);
+}
+
+.onboarding-footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+body[data-onboarding-open="true"] {
+    overflow: hidden;
+}
+
+@media (max-width: 640px) {
+    .top-bar {
+        flex-direction: column;
+        gap: 1rem;
+        text-align: center;
+    }
+
+    .top-nav {
+        flex-wrap: wrap;
+        justify-content: center;
+    }
+
+    main {
+        margin-top: 1.5rem;
+        gap: 1.5rem;
+    }
+
+    .card {
+        padding: 1.5rem;
+    }
+
+    .onboarding-dialog {
+        padding: 1.5rem;
+    }
+}


### PR DESCRIPTION
## Summary
- add an illustrated onboarding modal that explains navigation, quiz usage, and available assistance
- ensure the guide only appears on first visit, can be relaunched from the help button, and saves its state in localStorage
- provide gentle alert styling and interactive status messages for quiz validation and form submission

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfbb76a050832089a1e05dd40dcf7f