### PR TITLE
Improve CSV import delimiter detection

### DIFF
--- a/apps/frontend/src/lib/csv.ts
+++ b/apps/frontend/src/lib/csv.ts
@@ -3,7 +3,14 @@ import { Question } from './types';
 import { normalize } from './normalize';
 
 export function detectDelimiter(csv: string): string {
-  return csv.includes(';') && !csv.includes(',') ? ';' : ',';
+  const firstLine = csv.split(/\r?\n/, 1)[0] ?? '';
+  const commaCount = (firstLine.match(/,/g) ?? []).length;
+  const semicolonCount = (firstLine.match(/;/g) ?? []).length;
+
+  if (semicolonCount > commaCount) return ';';
+  if (commaCount > semicolonCount) return ',';
+  if (semicolonCount > 0) return ';';
+  return ',';
 }
 
 export function parseCSV(csv: string): { questions: Question[]; errors: string[] } {

--- a/tests/unit/csv.test.ts
+++ b/tests/unit/csv.test.ts
@@ -10,4 +10,16 @@ describe('parseCSV', () => {
     expect(errors.length).toBe(0);
     expect(questions.length).toBeGreaterThan(0);
   });
+
+  it('détecte les points-virgules même avec des virgules dans les valeurs', () => {
+    const semicolonCsv = [
+      'ID;Type;Question;Choix;Réponse;Thème;RéférenceCours;MotCléRecherchePDF;PagePDF',
+      '1;QCM;Quelle touche, pour copier?;Ctrl+C|Ctrl+V;Ctrl+C;Clavier;Chapitre 1;;10'
+    ].join('\n');
+
+    const { questions, errors } = parseCSV(semicolonCsv);
+    expect(errors).toHaveLength(0);
+    expect(questions).toHaveLength(1);
+    expect(questions[0].choices).toEqual(['Ctrl+C', 'Ctrl+V']);
+  });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,19 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   root: 'apps/frontend',
   plugins: [react()],
   server: {
     port: 5173
+  },
+  test: {
+    include: [resolve(__dirname, 'tests/unit/**/*.test.ts')],
+    globals: true,
+    environment: 'node'
   }
 });


### PR DESCRIPTION
## Summary
- improve CSV delimiter detection by comparing counts of commas and semicolons in the header
- add a regression test covering semicolon separated CSV files that contain commas in values
- configure Vitest to pick up the shared unit test suite from the repository root

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e14703e3cc8320929d53c0ed0bdecf